### PR TITLE
Fixed the check method of default value

### DIFF
--- a/lib/rspec/virtus/matcher.rb
+++ b/lib/rspec/virtus/matcher.rb
@@ -19,8 +19,8 @@ module RSpec
         self
       end
 
-      def with_default(default_value)
-        @options[:default_value] = default_value
+      def with_default(default_value, evaluate: false)
+        @options[:default_value] = {value: default_value, evaluate: evaluate}
         self
       end
 
@@ -79,9 +79,9 @@ module RSpec
 
         case value
         when ::Proc
-          value.call(@instance, attribute)
+          @options[:default_value][:evaluate] ? value.call(@instance, attribute) : :proc
         when ::Symbol
-          @instance.__send__(value)
+          @options[:default_value][:evaluate] && @instance.respond_to?(value, true) ? @instance.__send__(value) : value
         else
           value
         end
@@ -99,7 +99,7 @@ module RSpec
 
       def default_value_correct?
         return true unless @options[:default_value]
-        attribute_default_value == @options[:default_value]
+        attribute_default_value == @options[:default_value][:value]
       end
 
       def required?

--- a/spec/acceptance/rspec_virtus_spec.rb
+++ b/spec/acceptance/rspec_virtus_spec.rb
@@ -23,7 +23,8 @@ describe ::DummyPost do
   it { is_expected.to have_attribute(:body).of_type(String) }
   it { is_expected.to have_attribute(:comments).of_type(Array[String]) }
   it { is_expected.to have_attribute(:greeting).of_type(String).with_default('Hello!') }
-  it { is_expected.to have_attribute(:default_lambda).of_type(String).with_default('Wow!') }
-  it { is_expected.to have_attribute(:customs).of_type(String).with_default('Foo!') }
+  it { is_expected.to have_attribute(:default_lambda).of_type(String).with_default('Wow!', evaluate: true) }
+  it { is_expected.to have_attribute(:default_lambda).of_type(String).with_default(:proc) }
+  it { is_expected.to have_attribute(:customs).of_type(String).with_default('Foo!', evaluate: true) }
   it { is_expected.to have_attribute(:some_required).of_type(String).with_default('FooBar').with_required(true) }
 end

--- a/spec/lib/rspec/virtus/matcher_spec.rb
+++ b/spec/lib/rspec/virtus/matcher_spec.rb
@@ -135,7 +135,7 @@ describe RSpec::Virtus::Matcher do
     end
 
     it 'adds an option to allow the default value to be checked' do
-      options_default_value = subject.instance_variable_get(:@options)[:default_value]
+      options_default_value = subject.instance_variable_get(:@options)[:default_value][:value]
       expect(options_default_value).to eql('My Default')
     end
   end


### PR DESCRIPTION
Modification of default value check method
####  symbol
- If there is no corresponding method, set the argument as a default value

#### proc
- `evaluate: true` is specified: execute proc and set to default_value
- `evaluate`is not specified: default_value is ':proc'